### PR TITLE
Rename Writer class

### DIFF
--- a/src/main/java/pereira/tostain/SchemaGenerator.java
+++ b/src/main/java/pereira/tostain/SchemaGenerator.java
@@ -1,15 +1,19 @@
 package pereira.tostain;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 import java.util.Objects;
 
-public final class Writer {
+public final class SchemaGenerator {
 
     public void writeLines(Writer writer, List<String> lines) throws IOException {
         Objects.requireNonNull(writer);
         Objects.requireNonNull(lines);
 
-        writer.writeLines(writer, lines);
+        for (var line : lines) {
+            writer.append(line);
+        }
+        writer.flush();
     }
 }

--- a/src/test/java/pereira/tostain/SchemaGeneratorTest.java
+++ b/src/test/java/pereira/tostain/SchemaGeneratorTest.java
@@ -7,11 +7,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class WriterTest {
+public class SchemaGeneratorTest {
 
     @Test
     public void writerPreconditions() {
-        var writer = new Writer();
+        var writer = new SchemaGenerator();
         assertAll(
             () -> assertThrows(NullPointerException.class, () -> writer.writeLines(null, List.of("test")))
         );


### PR DESCRIPTION
Rename Writer class to SchemaGenerator to avoid confusion with java's Writer class