### PR TITLE
Improve the instanciation of subtypedependencies

### DIFF
--- a/src/main/java/com/github/forax/umldoc/classfile/ClassFileParser.java
+++ b/src/main/java/com/github/forax/umldoc/classfile/ClassFileParser.java
@@ -4,16 +4,13 @@ import static com.github.forax.umldoc.core.Call.Group.EMPTY_GROUP;
 import static java.util.Objects.requireNonNull;
 import static org.objectweb.asm.Opcodes.ASM9;
 
-import com.github.forax.umldoc.core.Entity;
 import com.github.forax.umldoc.core.Method;
-import com.github.forax.umldoc.core.SubtypeDependency;
 import com.github.forax.umldoc.core.TypeInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.objectweb.asm.ClassReader;
@@ -31,11 +28,11 @@ final class ClassFileParser {
    * Result of a call to {@link ClassFileParser#parseClass(InputStream)}.
    */
   record ParsingResult(EntityBuilder entityBuilder, List<Delegation> delegations,
-                       List<TypeInfo> interfaces) {
+                       List<TypeInfo> superTypes) {
     ParsingResult {
       requireNonNull(entityBuilder);
       requireNonNull(delegations);
-      requireNonNull(interfaces);
+      requireNonNull(superTypes);
     }
   }
 
@@ -46,7 +43,7 @@ final class ClassFileParser {
   public static ParsingResult parseClass(InputStream inputStream) throws IOException {
     var entityBuilder = new EntityBuilder();
     var delegations = new ArrayList<Delegation>();
-    var interfacesList = new ArrayList<TypeInfo>();
+    var superTypes = new ArrayList<TypeInfo>();
     var classReader = new ClassReader(inputStream);
     classReader.accept(new ClassVisitor(ASM9) {
       @Override
@@ -54,9 +51,12 @@ final class ClassFileParser {
                         String superName, String[] interfaces) {
         entityBuilder.stereotype(Utils.toStereotype(access));
         entityBuilder.type(TypeInfo.of(name.replace('/', '.')));
+        if (superName != null) {
+          superTypes.add(TypeInfo.of(superName.replace('/', '.')));
+        }
         for (var anInterface : interfaces) {
           var typeInfo = TypeInfo.of(anInterface.replace('/', '.'));
-          interfacesList.add(typeInfo);
+          superTypes.add(typeInfo);
         }
       }
 
@@ -112,7 +112,7 @@ final class ClassFileParser {
         };
       }
     }, 0);
-    return new ParsingResult(entityBuilder, delegations, interfacesList);
+    return new ParsingResult(entityBuilder, delegations, superTypes);
   }
 
   private static TypeInfo decodeField(String signature) {

--- a/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
+++ b/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
@@ -18,7 +18,6 @@ import com.github.forax.umldoc.core.TypeInfo;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleReference;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -101,7 +99,7 @@ public final class ModuleScrapper {
       var entity = entityBuilder.build();
       entityMap.put(javaClassName(entity.type()), entity);
 
-      var interfacesAsJavaclassname = parsingResult.interfaces().stream()
+      var interfacesAsJavaclassname = parsingResult.superTypes().stream()
               .map(TypeInfo::name)
               .toList();
       if (!interfacesAsJavaclassname.isEmpty()) {

--- a/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
+++ b/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
@@ -132,12 +132,12 @@ public final class ModuleScrapper {
                                                    Map<String, Entity> entityMap) {
     return subtypeInfoDependencies.entrySet().stream()
             .map(entry -> {
-              var superType = entry.getKey();
-              var subtypes = entry.getValue().stream()
+              var subtype = entry.getKey();
+              var superTypes = entry.getValue().stream()
                       .map(entityMap::get)
                       .toList();
               var subtypeDependencies = new ArrayList<Dependency>();
-              for (var subtype : subtypes) {
+              for (var superType : superTypes) {
                 var subtypeDependency = new SubtypeDependency(superType, subtype);
                 subtypeDependencies.add(subtypeDependency);
               }

--- a/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
+++ b/src/main/java/com/github/forax/umldoc/classfile/ModuleScrapper.java
@@ -122,7 +122,15 @@ public final class ModuleScrapper {
                   a.cardinality));
         });
 
-    var subtypeDependenciesStream = subtypeInfoDependencies.entrySet().stream()
+    var subtypeDependenciesStream = getSubtypeDependencies(subtypeInfoDependencies, entityMap);
+    var dependencies = Stream.concat(associationsStream, subtypeDependenciesStream).toList();
+    return new Package(packageName, List.copyOf(entityMap.values()), dependencies);
+  }
+
+  //package private for testing
+  static Stream<Dependency> getSubtypeDependencies(Map<Entity, List<String>> subtypeInfoDependencies,
+                                                   Map<String, Entity> entityMap) {
+    return subtypeInfoDependencies.entrySet().stream()
             .map(entry -> {
               var superType = entry.getKey();
               var subtypes = entry.getValue().stream()
@@ -136,9 +144,6 @@ public final class ModuleScrapper {
               return subtypeDependencies;
             })
             .flatMap(ArrayList::stream);
-
-    var dependencies = Stream.concat(associationsStream, subtypeDependenciesStream).toList();
-    return new Package(packageName, List.copyOf(entityMap.values()), dependencies);
   }
 
 

--- a/src/test/java/com/github/forax/umldoc/classfile/ModuleScrapperTest.java
+++ b/src/test/java/com/github/forax/umldoc/classfile/ModuleScrapperTest.java
@@ -7,6 +7,8 @@ import com.github.forax.umldoc.core.Entity;
 import com.github.forax.umldoc.core.Field;
 import com.github.forax.umldoc.core.SubtypeDependency;
 import com.github.forax.umldoc.core.TypeInfo;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -73,6 +75,19 @@ public class ModuleScrapperTest {
     } catch (InvocationTargetException e) {
       assertInstanceOf(AssertionError.class, e.getCause());
     }
+  }
+
+  @Test
+  public void testGetSubtypeDependencies() {
+    var testInterface = new Entity(Set.of(), TypeInfo.of("TestInterface"), Entity.Stereotype.INTERFACE, List.of(), List.of());
+    var entity = new Entity(Set.of(), TypeInfo.of("Test"), Entity.Stereotype.CLASS, List.of(), List.of());
+    var subtypeInfoDependencies = new HashMap<Entity, List<String>>();
+    subtypeInfoDependencies.put(entity, List.of("TestInterface"));
+    var entityMap = new HashMap<String, Entity>();
+    entityMap.put("TestInterface", testInterface);
+    entityMap.put("Test", entity);
+    var subtypeDependencies = Stream.of(new SubtypeDependency(testInterface, entity));
+    assertEquals(ModuleScrapper.getSubtypeDependencies(subtypeInfoDependencies, entityMap).toList(), subtypeDependencies.toList());
   }
 
   @Test

--- a/src/test/java/com/github/forax/umldoc/classfile/ModuleScrapperTest.java
+++ b/src/test/java/com/github/forax/umldoc/classfile/ModuleScrapperTest.java
@@ -82,7 +82,7 @@ public class ModuleScrapperTest {
     var testInterface = new Entity(Set.of(), TypeInfo.of("TestInterface"), Entity.Stereotype.INTERFACE, List.of(), List.of());
     var entity = new Entity(Set.of(), TypeInfo.of("Test"), Entity.Stereotype.CLASS, List.of(), List.of());
     var subtypeInfoDependencies = new HashMap<Entity, List<String>>();
-    subtypeInfoDependencies.put(entity, List.of("TestInterface"));
+    subtypeInfoDependencies.put(entity, List.of("TestInterface", "java.lang.Iterable"));
     var entityMap = new HashMap<String, Entity>();
     entityMap.put("TestInterface", testInterface);
     entityMap.put("Test", entity);


### PR DESCRIPTION
This PR :
- fix the instanciated SubtypeDependency objects inside the ModuleScrapper (supertype and subtype were inverted)
- fix a NPE that was thrown when an interfaces implemented by an entity is not part of the same package
- add superName as a supertype