### PR TITLE
Add a cache to avoid recomputing entities names during Sequence Diagram Generation.

### DIFF
--- a/src/main/java/com/github/forax/umldoc/gen/ExecutionPathResolver.java
+++ b/src/main/java/com/github/forax/umldoc/gen/ExecutionPathResolver.java
@@ -94,6 +94,12 @@ public class ExecutionPathResolver {
     throw new IllegalStateException();
   }
 
+  static Entity getEntityFromMethodName(String methodName, Set<Entity> entities,
+                                        Map<String, Entity> cache) {
+    return cache.computeIfAbsent(methodName, name ->
+            ExecutionPathResolver.findEntityFromMethodName(name, entities));
+  }
+
   //Find match ?
   static Method findMethodInEntity(Call.MethodCall methodCall, Entity entity) {
 

--- a/src/main/java/com/github/forax/umldoc/gen/PlantUmlGenerator.java
+++ b/src/main/java/com/github/forax/umldoc/gen/PlantUmlGenerator.java
@@ -13,7 +13,9 @@ import com.github.forax.umldoc.core.Package;
 import com.github.forax.umldoc.core.SubtypeDependency;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -138,6 +140,7 @@ public final class PlantUmlGenerator implements Generator {
   }
 
   private static void generateCalls(Call.Group group, Set<Entity> entities,
+                                    Map<String, Entity> cache,
                                     Writer writer) throws IOException {
     if (group.equals(Call.Group.EMPTY_GROUP)) {
       return;
@@ -156,6 +159,7 @@ public final class PlantUmlGenerator implements Generator {
         generateCalls(
                 groupCall,
                 entities,
+                cache,
                 writer
         );
 
@@ -165,7 +169,9 @@ public final class PlantUmlGenerator implements Generator {
       } else if (call instanceof Call.MethodCall methodCall) {
         var srcEntityName = methodCall.ownerName();
         var dstEntityName = ExecutionPathResolver
-                .findEntityFromMethodName(methodCall.name(), entities).type().name();
+                .getEntityFromMethodName(methodCall.name(), entities, cache)
+                .type().name();
+
         generateMethodCall(srcEntityName, dstEntityName, methodCall.name(), writer);
       } else {
         throw new IllegalStateException("Unknown Call subtype : must be Group or MethodCall");
@@ -211,8 +217,8 @@ public final class PlantUmlGenerator implements Generator {
     var entities = p.entities().stream()
             .filter(entity -> entity.type().name().startsWith(p.name()))
             .collect(Collectors.toSet());
-
-    generateCalls(firstGroup, entities, writer);
+    var cache = new HashMap<String, Entity>();
+    generateCalls(firstGroup, entities, cache, writer);
 
     if (header) {
       addFooter(writer);


### PR DESCRIPTION
Add a cache (Map) to avoid recomputing values each time we want to get the Entity name from a method name in PlantUmlGenerator and MermaidGenerator.